### PR TITLE
[read all before merge] bug fix and more compatitable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,11 @@ jobs:
         # docs: https://github.com/marketplace/actions/golang-cgo-cross-compiler#inputs
         with:
           xgo_version: latest
-          go_version: 1.17
+          go_version: 1.18
           dest: build
           pkg: cmd
           prefix: server
-          targets: windows/386,windows/amd64,linux/386,linux/amd64,darwin/amd64
+          targets: windows/386,windows/amd64,linux/386,linux/amd64,darwin/amd64,darwin/arm64
           # Prints the build commands as compilation progresses (default false)
           x: true
           ldflags: -w
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'adopt'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/README.md
+++ b/README.md
@@ -24,15 +24,19 @@ Another option would've been to code an upstream proxy server and connect burp t
 3. Check your new 'Awesome TLS' tab in Burp for configuration settings and start hacking!
 
 ## Manual build Instructions
+
 This extension was developed with JetBrains IntelliJ (and GoLand) IDE. 
 The build instructions below assume you're using the same tools to build.
 See [workflows](.github/workflows) for the target programming language versions.
 
-1. Compile the go package within `./src-go/`. Run `cd ./src-go/server && go build -o ../../src/main/resources/{OS}-{ARCH}/server.{EXT} -buildmode=c-shared ./cmd/main.go`, replacing `{OS}-{ARCH}` with your OS and CPU architecture and `{EXT}` with your platform's preferred extension for dynamic C libraries. For example: `linux-x86-64/server.so`. See the [JNA docs](https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md) for more info about supported platforms.
-2. Compile the GUI form `SettingsTab.form` into Java code via `Build > Build project`.
-3. Build the jar with Gradle.
+1. Compile the go package within `./src-go/`. Run `cd ./src-go/server && go build -o ../../src/main/resources/${BUILD_OS}-${BUILD_OPT_ARCH}/server.${BUILD_EXT} -buildmode=c-shared -trimpath -ldflags='-s -w' ./cmd/main.go`, replacing `{OS}-{ARCH}` with your OS and CPU architecture and `${BUILD_EXT}` with your platform's preferred extension for dynamic C libraries. For example: `linux-x86-64/server.so`.
+Apple Silicon users should use `darwin/arm64` for Golang, `darwin/aarch64` for JNA, `.dylib` as extension for native library.
 
-You should now have one jar file that works with Burp on your operating system.
+2. See the [JNA docs](https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md) for more info about supported platforms. For prebuilt-supported platform list, check [here](https://github.com/java-native-access/jna/tree/master/lib/native).
+3. Compile the GUI form `SettingsTab.form` into Java code via `Build > Build project`.
+4. Build the jar with Gradle, for example: after downloading all dependencies via IDE, then run `gradle buildJar` or click on the right side panel icon for corresponding task.
+
+You should now have one jar file that works with Burp on your operating system at location `./build/libs`.
 
 ## License
 [GPL V3](./LICENSE)

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,10 @@ copy_macos() {
   copy "server-darwin-10.16-amd64.dylib" "darwin-x86-64"
 }
 
+copy_macos_m1() {
+  copy "server-darwin-10.16-arm64.dylib" "darwin-arm64"
+}
+
 copy_linux_386() {
   copy "server-linux-386.so" "linux-x86"
 }
@@ -72,6 +76,10 @@ cleanup
 copy_windows_386
 buildJar "windows-i386"
 
+cleanup
+copy_macos_m1
+buildJar "macos-arm64"
+
 # build single cross-platform fat jar
 cleanup
 copy_macos
@@ -79,4 +87,5 @@ copy_linux_386
 copy_linux_amd64
 copy_windows_amd64
 copy_windows_386
+copy_macos_m1
 buildJar "fat"

--- a/src/main/java/burp/Settings.java
+++ b/src/main/java/burp/Settings.java
@@ -8,7 +8,7 @@ public class Settings {
     private final String tlsFingerprintFilePath = "TlsFingerprintFilePath";
 
     public static final String DEFAULT_ADDRESS = "127.0.0.1:8887";
-    public static final int DEFAULT_TIMEOUT = 10;
+    public static final String DEFAULT_TIMEOUT = "10";
     public static final String DEFAULT_TLS_FINGERPRINT = "Default";
 
     public Settings(IBurpExtenderCallbacks callbacks) {
@@ -17,14 +17,20 @@ public class Settings {
     }
 
     private void setDefaults() {
-        if (this.read(this.address) == null)
+        if (this.read(this.address) == null){
             this.write(this.address, DEFAULT_ADDRESS);
+        }
 
-        if (this.read(this.timeout) == null)
-            this.write(this.timeout, String.valueOf(DEFAULT_TIMEOUT));
 
-        if (this.read(this.tlsFingerprint) == null)
+        if (this.read(this.timeout) == null){
+            this.write(this.timeout, DEFAULT_TIMEOUT);
+        }
+
+
+        if (this.read(this.tlsFingerprint) == null) {
             this.write(this.tlsFingerprint, DEFAULT_TLS_FINGERPRINT);
+        }
+
     }
 
     public String read(String key, String defaultValue) {


### PR DESCRIPTION
optimize:

- upgrade golang to 1.18 in CI
- downgrade JDK to 11 in CI , for more users who is running JDK 11
- introduce more details about build plugins manually, especially for Apple Silicon users who runs an ARM64 JDK instead of amd64 one. remove user identity related string in golang build by introducing `-trimpath -ldflags='-s -w'` param. Currently, it is still not available for users to compile against Apple M1 automatically due to bugs listed below.

bug fix:
- when load plugin, it will tells you in `Settings.java` :

```java
    public int getTimeout() {
        return Integer.parseInt(this.read(this.timeout));
    }
```

number conversion failed due to timeout is NULL. Since I'm not that familiar with Burp extension development, but I think it might because it only allows all settings in String instead of int here. So I change the `Settings.timeout` to String and removed redundant type conversion.

**HOWEVER**

There are still bugs here:
- unload extension will result in:
```
java.lang.NoClassDefFoundError: Could not initialize class burp.ServerLibrary
	at burp.BurpExtender.extensionUnloaded(BurpExtender.java:76)
	at burp.c6o.h(Unknown Source)
	at burp.izp.b(Unknown Source)
	at burp.a8_.lambda$toggleLoadedState$1(Unknown Source)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

- `server.dylib` is loaded, but no port get listened. I have no idea how to debugging it.


If you could give me some help about fix the bug, I will build a more strong auto build script to help all of us. 

Thanks for your excellent idea.