### PR TITLE
feat: Add Zstd decompression, HTTP fallback, logging, and debug mode

### DIFF
--- a/src-go/server/go.mod
+++ b/src-go/server/go.mod
@@ -1,6 +1,6 @@
 module server
 
-go 1.22.0
+go 1.23
 
 toolchain go1.25.5
 
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
-	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/quic-go/quic-go v0.48.1 // indirect
 	github.com/tam7t/hpkp v0.0.0-20160821193359-2b70b4024ed5 // indirect
 	golang.org/x/crypto v0.29.0 // indirect

--- a/src-go/server/go.sum
+++ b/src-go/server/go.sum
@@ -14,6 +14,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
+github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/quic-go v0.48.1 h1:y/8xmfWI9qmGTc+lBr4jKRUWLGSlSigv847ULJ4hYXA=

--- a/src-go/server/transport.go
+++ b/src-go/server/transport.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	tls_client "github.com/bogdanfinn/tls-client"
 	"github.com/bogdanfinn/tls-client/profiles"
 	utls "github.com/bogdanfinn/utls"
-	"strings"
 )
 
 type TransportConfig struct {
@@ -38,6 +39,9 @@ type TransportConfig struct {
 
 	// HeaderOrder is the order of headers to be sent in the request.
 	HeaderOrder []string
+
+	// Debug enables verbose logging for the request
+	Debug bool
 }
 
 func ParseTransportConfig(data string) (*TransportConfig, error) {

--- a/src/main/java/burp/Extension.java
+++ b/src/main/java/burp/Extension.java
@@ -17,6 +17,7 @@ public class Extension implements BurpExtension {
     private MontoyaApi api;
     private Gson gson;
     private Settings settings;
+    private ServerLibrary.LogCallback logCallback;
 
     private static final String HEADER_KEY = "Awesometlsconfig";
 
@@ -25,6 +26,10 @@ public class Extension implements BurpExtension {
         this.api = api;
         this.gson = new Gson();
         this.settings = new Settings(api);
+
+        this.logCallback = msg -> api.logging().logToOutput("[Go Server] " + msg);
+        ServerLibrary.INSTANCE.SetLogger(this.logCallback);
+        api.logging().logToOutput("Awesome TLS Extension initialized.");
 
         api.extension().setName("Awesome TLS");
         api.extension().registerUnloadingHandler(() -> {

--- a/src/main/java/burp/ServerLibrary.java
+++ b/src/main/java/burp/ServerLibrary.java
@@ -12,6 +12,12 @@ public interface ServerLibrary extends Library {
     String StopServer();
 
     String GetFingerprints();
+    
+    interface LogCallback extends com.sun.jna.Callback {
+        void invoke(String msg);
+    }
+    
+    void SetLogger(LogCallback callback);
 
     void SmokeTest();
 }

--- a/src/main/java/burp/Settings.java
+++ b/src/main/java/burp/Settings.java
@@ -13,6 +13,7 @@ public class Settings {
     private final String hexClientHello = "HexClientHello";
     private final String useInterceptedFingerprint = "UseInterceptedFingerprint";
     private final String httpTimeout = "HttpTimeout";
+    private final String debug = "Debug";
 
     public static final String DEFAULT_SPOOF_PROXY_ADDRESS = "127.0.0.1:8887";
     public static final String DEFAULT_INTERCEPT_PROXY_ADDRESS = "127.0.0.1:8886";
@@ -20,6 +21,7 @@ public class Settings {
     public static final Integer DEFAULT_HTTP_TIMEOUT = 30;
     public static final String DEFAULT_TLS_FINGERPRINT = "default";
     public static final Boolean USE_INTERCEPTED_FINGERPRINT = false;
+    public static final Boolean DEFAULT_DEBUG = false;
 
     public Settings(MontoyaApi api) {
         this.storage = api.persistence().preferences();
@@ -62,6 +64,14 @@ public class Settings {
 
     public void write(String key, Integer value) {
         this.storage.setInteger(key, value);
+    }
+
+    public Boolean getDebug() {
+        return this.read(this.debug, DEFAULT_DEBUG);
+    }
+
+    public void setDebug(Boolean debug) {
+        this.write(this.debug, debug);
     }
 
     public String getSpoofProxyAddress() {
@@ -132,6 +142,7 @@ public class Settings {
         transportConfig.UseInterceptedFingerprint = this.getUseInterceptedFingerprint();
         transportConfig.BurpAddr = this.getBurpProxyAddress();
         transportConfig.InterceptProxyAddr = this.getInterceptProxyAddress();
+        transportConfig.Debug = this.getDebug();
         return transportConfig;
     }
 }

--- a/src/main/java/burp/SettingsTab.java
+++ b/src/main/java/burp/SettingsTab.java
@@ -26,7 +26,9 @@ public class SettingsTab {
     private JPanel panelAdvanced;
     private JButton buttonSaveAdvanced;
     private JLabel labelHexClientHello;
+
     private JTextField textFieldHexClientHello;
+    private JCheckBox checkBoxDebug;
 
     public SettingsTab(Settings settings) {
         textFieldInterceptProxyAddress.setText(settings.getInterceptProxyAddress());
@@ -35,6 +37,8 @@ public class SettingsTab {
         textFieldHexClientHello.setText(settings.getHexClientHello());
         spinnerHttpTimout.setValue(settings.getHttpTimeout());
         checkBoxButtonUseInterceptedFingerprint.setSelected(settings.getUseInterceptedFingerprint());
+        checkBoxDebug.setSelected(settings.getDebug());
+
         for (var item : settings.getFingerprints()) {
             comboBoxFingerprint.addItem(item);
         }
@@ -45,6 +49,7 @@ public class SettingsTab {
             settings.setFingerprint((String) comboBoxFingerprint.getSelectedItem());
             settings.setHexClientHello(textFieldHexClientHello.getText());
             settings.setHttpTimeout((int) spinnerHttpTimout.getValue());
+            settings.setDebug(checkBoxDebug.isSelected());
         });
 
         buttonSaveAdvanced.addActionListener(e -> {
@@ -78,7 +83,7 @@ public class SettingsTab {
         tabbedPaneTab = new JTabbedPane();
         panelMain.add(tabbedPaneTab, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(200, 200), null, 0, false));
         panelSettings = new JPanel();
-        panelSettings.setLayout(new GridLayoutManager(10, 1, new Insets(0, 0, 0, 0), -1, -1));
+        panelSettings.setLayout(new GridLayoutManager(11, 1, new Insets(0, 0, 0, 0), -1, -1));
         tabbedPaneTab.addTab("settings", panelSettings);
         labelSpoofProxyAddress = new JLabel();
         labelSpoofProxyAddress.setRequestFocusEnabled(false);
@@ -103,9 +108,13 @@ public class SettingsTab {
         spinnerHttpTimout = new JSpinner();
         spinnerHttpTimout.setToolTipText("The maximum amount of time a dial will wait for a connect to complete.");
         panelSettings.add(spinnerHttpTimout, new GridConstraints(7, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        checkBoxDebug = new JCheckBox();
+        checkBoxDebug.setText("Enable Server Logging");
+        checkBoxDebug.setToolTipText("Enable verbose logging from the Go server.");
+        panelSettings.add(checkBoxDebug, new GridConstraints(8, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
-        panelSettings.add(panel1, new GridConstraints(9, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panelSettings.add(panel1, new GridConstraints(10, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         labelHexClientHello = new JLabel();
         labelHexClientHello.setRequestFocusEnabled(false);
         labelHexClientHello.setText("Hex Client Hello:");
@@ -117,7 +126,7 @@ public class SettingsTab {
         panelSettings.add(textFieldHexClientHello, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
         buttonSave = new JButton();
         buttonSave.setText("Save all settings");
-        panelSettings.add(buttonSave, new GridConstraints(8, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panelSettings.add(buttonSave, new GridConstraints(9, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         panelAdvanced = new JPanel();
         panelAdvanced.setLayout(new GridLayoutManager(7, 1, new Insets(0, 0, 0, 0), -1, -1));
         panelAdvanced.setToolTipText("");

--- a/src/main/java/burp/TransportConfig.java
+++ b/src/main/java/burp/TransportConfig.java
@@ -48,5 +48,13 @@ public class TransportConfig {
     /**
      * the order of headers to be sent in the request.
      */
+    /**
+     * the order of headers to be sent in the request.
+     */
     public String[] HeaderOrder;
+
+    /**
+     * Enable verbose server logging.
+     */
+    public boolean Debug;
 }


### PR DESCRIPTION
# Pull Request: Enhanced Observability, Protocol Reliability, and Zstd Support

## Description

### Overview
This pull request addresses critical interoperability issues enabling the extension to handle a wider range of server responses (Zstd compression, HTTP-over-HTTPS fallback) and significantly improves the developer experience with a new, configurable debugging system that bridges Go and Java.

### Changes Made

#### 1. **Automatic HTTP Fallback Mechanism**
**Files:** `src-go/server/server.go`
- **Problem:** When targeting an endpoint that speaks plaintext HTTP on a port expected to be HTTPS (common with misconfigured servers or intermediate proxies), the Go client would terminate with a fatal `http: server gave HTTP response to HTTPS client` error, dropping the response.
- **Solution:** Implemented a retry logic that catches this specific handshake error. The server now logs a warning, automatically downgrades the scheme to `http`, and retries the request, ensuring the response (e.g., an error page or redirect) is captured and sent back to Burp.

#### 2. **Zstd Decompression Support**
**Files:** `src-go/server/server.go`
- **Problem:** Burp Suite does not natively support `zstd` content encoding, leading to unreadable binary payloads in the Repeater/Proxy.
- **Solution:** Added transparent decompression for `Content-Encoding: zstd`. The Go server now detects zstd headers, decompresses the body using `klauspost/compress/zstd`, and removes the encoding header so Burp treats it as plain text.

#### 3. **Debug Mode & UI Integration**
**Files:** `src/main/java/burp/SettingsTab.java`, `TransportConfig.java`, `Settings.java`
- **New Feature:** Added an **"Enable Server Logging"** checkbox to the "Awesome TLS" settings tab.
- **Implementation:** 
  - The debug state is persisted in Burp's preferences.
  - It is dynamically passed to the Go server via the `Awesometlsconfig` header structure.
  - Updated the IntelliJ GUI Designer generated code (`$$$setupUI$$$`) to accommodate the new checkbox control.

#### 4. **Cross-Language Logging Bridge**
**Files:** `src/main/java/burp/ServerLibrary.java`, `src-go/server/server.go`, `src/main/java/burp/Extension.java`
- **Improvement:** Replaced `fmt.Println` with a robust callback system.
- **Tech Detail:** Implemented a `LogCallback` interface extending `com.sun.jna.Callback`. This allows the Go server to invoke a Java method (`invoke(String msg)`) to pipe logs directly into Burp's extension output stream.
- **Refined Format:**
  - **URL-First:** Logs now lead with the `Request URL` for easier scanning.
  - **Compact Headers:** Response headers are formatted on a single line (`[Key: Val]`) to reduce log noise.
  - **Conditional:** Logs are only emitted if the new `Debug` flag is enabled.

#### 5. **Go Module & Build Updates**
**Files:** `src-go/server/go.mod`, `src-go/server/go.sum`
- Updated Go module dependencies to support the new compression libraries and server structures.
- Refined `main.go` entry point.

### Benefits
- **Resilience:** Prevents dropped connections on protocol mismatches.
- **Visibility:** Native Zstd support reveals previously opaque payloads.
- **Debuggability:** Users can now see exactly what the Go server is doing (headers, status codes, URLs) without leaving Burp, but can also turn it off to keep the UI clean.
