### PR TITLE
Update Go version to `1.24.1` in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         # docs: https://github.com/marketplace/actions/golang-cgo-cross-compiler#inputs
         with:
           xgo_version: latest
-          go_version: 1.21
+          go_version: 1.24.1
           dest: build
           pkg: cmd
           prefix: server


### PR DESCRIPTION
The older go version specified in `release.yaml` caused certain symbols not to be available, causing darwin builds to fail.

Fixes #159.